### PR TITLE
Bugfix/Scheduler Memory Concurrency

### DIFF
--- a/kernel/src/arch/x86_64/mem/mem.c3
+++ b/kernel/src/arch/x86_64/mem/mem.c3
@@ -83,8 +83,12 @@ fn void? init(BootloaderPayload* payload) {
 macro usz page_size() => pmm::FRAME_SIZE;
 macro usz pages(bytes) => vmm::@pages(bytes);
 
-fn uptr? alloc_pages(usz pages) {
-    return vmm::@phys((uptr)pmm::alloc(pages)!);
+fn uptr? alloc_pages(usz pages, bool clear = false) {
+
+	uptr addr = vmm::@phys((uptr)pmm::alloc(pages)!);
+
+	if (clear) $$memset((char*)addr, (char)0, pages*pmm::FRAME_SIZE, false, (usz)1);
+	return addr;
 }
 
 fn void? free_pages(uptr addr, usz pages) {

--- a/kernel/src/arch/x86_64/mem/mem.c3
+++ b/kernel/src/arch/x86_64/mem/mem.c3
@@ -11,7 +11,7 @@ const uptr LEGACY_BIOS_BASE = 0x0;
 const uptr LEGACY_BIOS_LIMIT = 0xfffff;
 
 BuddyAllocator kAllocator @local;
-Spinlock lock @local;
+Spinlock lock, plock @local;
 fn Allocator get_allocator() => &kAllocator;
 
 faultdef MEMORY_UNAVAILABLE;
@@ -84,6 +84,8 @@ macro usz page_size() => pmm::FRAME_SIZE;
 macro usz pages(bytes) => vmm::@pages(bytes);
 
 fn uptr? alloc_pages(usz pages, bool clear = false) {
+	plock.acquire();
+    defer plock.release();
 
 	uptr addr = vmm::@phys((uptr)pmm::alloc(pages)!);
 
@@ -92,6 +94,8 @@ fn uptr? alloc_pages(usz pages, bool clear = false) {
 }
 
 fn void? free_pages(uptr addr, usz pages) {
+	plock.acquire();
+    defer plock.release();
     pmm::free((PhysAddr)(addr - vmm::@phys(0)), pages)!;
 }
 

--- a/kernel/src/authority/table.c3
+++ b/kernel/src/authority/table.c3
@@ -12,7 +12,7 @@ import lang;
     @param entriesSize : "number of entries in the table"
 *>
 fn void? ObjectTable.init(&self, usz entriesSize) {
-    ObjectSlot[] entries = ((ObjectSlot*)mem::alloc_pages(mem::pages(ObjectSlot.sizeof * entriesSize))!)[:entriesSize];
+    ObjectSlot[] entries = ((ObjectSlot*)mem::alloc_pages(mem::pages(ObjectSlot.sizeof * entriesSize), clear: true)!)[:entriesSize];
     void* bitmap = mem::alloc(entriesSize / ulong.sizeof);
 
     self.entries = entries;

--- a/kernel/src/process/task.c3
+++ b/kernel/src/process/task.c3
@@ -20,7 +20,10 @@ macro Handle? create_handle(Task* owner, Task* task, TaskObjectRights rights = {
 fn Task*? create(EntryPointFn entryPoint = null, usz stackSize = DEFAULT_KERNEL_STACK_SIZE, TaskState state = READY,
                 Task* parent = scheduler::get_current_task()) @private {
     if (stackSize < DEFAULT_KERNEL_STACK_SIZE) return INIT_STACK_TOO_SMALL?;
-    
+
+	scheduler::lock_scheduler();
+	defer scheduler::unlock_scheduler();
+
     uptr? stackBase;
     if (entryPoint != null && stackSize > 0) {
         // TODO: move stack setup in TaskSpace.init

--- a/shared/libs/mem/buddy_allocator.c3
+++ b/shared/libs/mem/buddy_allocator.c3
@@ -6,7 +6,7 @@ const float FREE_THRESHOLD = 0.25f;
 const usz SYS_BLOCK_SIZE = 0x1000;
 const usz SYS_REQUEST_BLOCKS = allocator::@order_size(MAX_ORDER) / SYS_BLOCK_SIZE; 
 
-alias AllocPageFn = fn uptr?(usz pages);
+alias AllocPageFn = fn uptr?(usz pages, bool clear = false);
 alias FreePageFn = fn void?(uptr ptr, usz pages);
 
 struct BuddyBlockHeader {


### PR DESCRIPTION
This bugfix addresses a problem with the scheduler/memory manager encountering a problem when reallocating memory for new Object Tables. A precondition required the Object Slot object pointer to be null, but memory was never cleared. 

A new page allocator lock also prevents race conditions.